### PR TITLE
Fetch and deploy app data to GitHub Pages

### DIFF
--- a/.github/workflows/update-apps.yml
+++ b/.github/workflows/update-apps.yml
@@ -1,0 +1,58 @@
+name: Update apps.json
+
+on:
+  schedule:
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate apps.json
+        run: npm run build:apps
+
+      - name: Commit and push if changed
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if [[ -n $(git status --porcelain apps.json) ]]; then
+            git add apps.json
+            git commit -m "chore: update apps.json"
+            git push
+          else
+            echo "No changes to commit"
+          fi
+
+      - name: Upload artifact for Pages
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: .
+
+  deploy:
+    needs: build
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+apps.json
+*.log

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# GenişKapı Store
+
+Tamamen otomatik olarak F-Droid verisini çekip `apps.json` üreten ve GitHub Pages üzerinde yayınlayan depo.
+
+## Nasıl Çalışır?
+- `scripts/generate-apps-json.mjs`: F-Droid `index-v1.json` verisini indirir ve `apps.json` oluşturur.
+- `index.html`: Sayfa yüklenince `apps.json` dosyasını fetch ederek uygulamaları listeler.
+- GitHub Actions workflow (`.github/workflows/update-apps.yml`): Her gün 03:00 UTC'de çalışır, `apps.json` güncellenirse commit edip Pages'e yayınlar.
+
+## Yerel Geliştirme
+```bash
+npm install
+npm run build:apps
+# apps.json oluşturulur
+```
+
+`index.html` yerelden açılabilir. Eğer CORS/cache problemi yaşarsanız basit bir HTTP sunucusu ile servis edin:
+```bash
+npx http-server -p 8000
+# Ardından http://localhost:8000 adresini açın
+```
+
+## GitHub Pages
+- Repo Settings → Pages → Build and deployment: "GitHub Actions" seçin.
+- Workflow ilk çalışmada artefaktı Pages'a yükler ve siteyi yayınlar.
+
+## Notlar
+- `apps.json` büyük bir dosyadır (binlerce uygulama). Gerektiğinde arama ve filtreleme için istemci tarafında sayfalama eklenebilir.

--- a/index.html
+++ b/index.html
@@ -515,7 +515,7 @@
         </div>
     </div>
 
-    <script src="apps.js"></script>
+    <!-- apps.js replaced by dynamic apps.json fetch -->
 
     <script>
         const appListEl = document.getElementById('app-list');
@@ -653,9 +653,20 @@
             }
         });
 
-        // Sayfa yüklendiğinde uygulamaları göster
-        document.addEventListener('DOMContentLoaded', () => {
-            displayApps(Object.values(apps));
+        // Sayfa yüklendiğinde apps.json'u yükle ve listeyi göster
+        let apps = {};
+        document.addEventListener('DOMContentLoaded', async () => {
+            try {
+                const res = await fetch('apps.json', { cache: 'no-store' });
+                apps = await res.json();
+                displayApps(Object.values(apps));
+            } catch (e) {
+                console.error('apps.json yüklenemedi', e);
+                appListEl.innerHTML = `<div style="grid-column: 1 / -1; text-align: center; padding: 3rem;">
+                    <h3>Veri yüklenemedi</h3>
+                    <p style="color: var(--text-secondary);">Lütfen daha sonra tekrar deneyin.</p>
+                </div>`;
+            }
         });
     </script>
 </body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,106 @@
+{
+  "name": "geniskapi-store",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "geniskapi-store",
+      "version": "1.0.0",
+      "dependencies": {
+        "node-fetch": "^3.3.2"
+      }
+    },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
+      "dependencies": {
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "geniskapi-store",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build:apps": "node scripts/generate-apps-json.mjs"
+  },
+  "dependencies": {
+    "node-fetch": "^3.3.2"
+  }
+}

--- a/scripts/generate-apps-json.mjs
+++ b/scripts/generate-apps-json.mjs
@@ -1,0 +1,115 @@
+import fs from 'fs/promises';
+import fetch from 'node-fetch';
+
+const FDROID_INDEX_URL = 'https://f-droid.org/repo/index-v1.json';
+
+function toArray(value) {
+  if (!value) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
+function resolveIconUrl(app) {
+  // Icons are provided via URL in index-v1.json as 'icon'
+  // Some entries may have paths; prefer full URLs if present
+  if (app.icon && app.icon.startsWith('http')) return app.icon;
+  if (app.icon) {
+    return `https://f-droid.org/repo/${app.icon}`;
+  }
+  return '';
+}
+
+function resolveScreenshots(app) {
+  const screenshots = toArray(app.screenshots);
+  return screenshots.map((s) => (s.startsWith('http') ? s : `https://f-droid.org/repo/${s}`));
+}
+
+function resolveApkUrl(packageName, versionCode, app) {
+  // index-v1.json has packages[packageName].versions with apkName
+  // Fallback to repo path pattern if needed
+  const apkName = app.packages?.[packageName]?.versions?.find(v => v.versionCode === versionCode)?.apkName;
+  if (apkName) {
+    return `https://f-droid.org/repo/${apkName}`;
+  }
+  return '';
+}
+
+async function fetchFdroidIndex() {
+  const res = await fetch(FDROID_INDEX_URL, { headers: { 'User-Agent': 'GenisKapiStoreBot/1.0' } });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch F-Droid index: ${res.status} ${res.statusText}`);
+  }
+  return res.json();
+}
+
+function pickFieldsFromApp(app) {
+  const packageName = app.packageName;
+  const name = app.name || app.summary || packageName;
+  const summary = app.summary || '';
+  const icon = resolveIconUrl(app);
+  const screenshots = resolveScreenshots(app);
+
+  // Build versions list (prefer latest first)
+  const versions = [];
+  const pkg = app.packages?.[packageName];
+  if (pkg && Array.isArray(pkg.versions)) {
+    const sorted = [...pkg.versions].sort((a, b) => (b.versionCode || 0) - (a.versionCode || 0));
+    for (const v of sorted) {
+      versions.push({ version: v.versionName || String(v.versionCode), apk: v.apkName ? `https://f-droid.org/repo/${v.apkName}` : '' });
+    }
+  } else if (Array.isArray(app.versions)) {
+    const sorted = [...app.versions].sort((a, b) => (b.versionCode || 0) - (a.versionCode || 0));
+    for (const v of sorted) {
+      versions.push({ version: v.versionName || String(v.versionCode), apk: v.apkName ? `https://f-droid.org/repo/${v.apkName}` : '' });
+    }
+  }
+
+  return {
+    packageName,
+    data: {
+      name,
+      summary,
+      icon,
+      screenshots,
+      versions,
+    },
+  };
+}
+
+async function main() {
+  console.log('Fetching F-Droid index...');
+  const index = await fetchFdroidIndex();
+  const appsOut = {};
+
+  const apps = index?.apps || index?.packages || [];
+  const appArray = Array.isArray(apps) ? apps : Object.values(apps);
+  for (const app of appArray) {
+    try {
+      const pkgName = app.packageName || app.package || app.id;
+      if (!pkgName) continue;
+      app.packageName = pkgName;
+      const { packageName, data } = pickFieldsFromApp(app);
+      if (data.versions.length === 0) {
+        // Try to infer versions from index.packages map if present
+        const pkgEntry = index?.packages?.[packageName];
+        if (pkgEntry && Array.isArray(pkgEntry.versions)) {
+          data.versions = [...pkgEntry.versions]
+            .sort((a, b) => (b.versionCode || 0) - (a.versionCode || 0))
+            .map(v => ({ version: v.versionName || String(v.versionCode), apk: v.apkName ? `https://f-droid.org/repo/${v.apkName}` : '' }));
+        }
+      }
+      appsOut[packageName] = data;
+    } catch (e) {
+      console.warn('Failed to process app', app?.packageName || app?.name, e.message);
+    }
+  }
+
+  const outPath = new URL('../apps.json', import.meta.url);
+  await fs.writeFile(outPath, JSON.stringify(appsOut, null, 2), 'utf-8');
+  console.log(`Wrote apps.json with ${Object.keys(appsOut).length} apps.`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+


### PR DESCRIPTION
Automate F-Droid app data fetching, `apps.json` generation, and daily GitHub Pages deployment for a self-updating app list.

---
<a href="https://cursor.com/background-agent?bcId=bc-59919c3c-169f-435a-9c59-bee5d0386b14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-59919c3c-169f-435a-9c59-bee5d0386b14">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

